### PR TITLE
Fix Spotify playlist items endpoint

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -382,7 +382,7 @@
       on_page_fetched = null
     ) {
       const all_tracks = [];
-      let next_url = `https://api.spotify.com/v1/playlists/${playlist_id}/tracks?limit=50`;
+      let next_url = `https://api.spotify.com/v1/playlists/${playlist_id}/items?limit=50`;
 
       while (next_url) {
         const response = await fetch(next_url, {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Spotify Playlist Page Search",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Search for songs within Spotify playlists",
   "author": "Kellen Mace",
   "homepage_url": "https://github.com/kellenmace/spotify-playlist-page-search/",


### PR DESCRIPTION
## Summary
- Update playlist paging request from `/tracks` to `/items` for Spotify Web API compatibility
- Bump extension version from 1.0.2 to 1.0.3

## Verification
- `node --check content-script.js`
- `node --check background.js`
- `node --check popup.js`
- `python3 -m json.tool manifest.json >/dev/null`